### PR TITLE
Auto-retry up to 3 times when executing scheduled buys

### DIFF
--- a/src/web/domain/dca.ts
+++ b/src/web/domain/dca.ts
@@ -38,13 +38,17 @@ function shouldExecuteRecurringBuy (recurringBuy: RecurringBuy): boolean {
 }
 
 async function executeScheduledBuys (subscriber: EventEmitter): Promise<void> {
+  const MAX_EXECUTE_ATTEMPTS = 3
   for (const buy of recurringBuys.values()) {
     if (shouldExecuteRecurringBuy(buy)) {
-      try {
-        await tryBuy(buy)
-        subscriber.emit('success', 'Recurring buy completed')
-      } catch (e) {
-        subscriber.emit('error', e)
+      for (let i = 0; i < MAX_EXECUTE_ATTEMPTS; i++) {
+        try {
+          await tryBuy(buy)
+          subscriber.emit('success', 'Recurring buy completed')
+          break
+        } catch (e) {
+          subscriber.emit('error', e)
+        }
       }
     }
   }


### PR DESCRIPTION
Sometimes order execution may fail due to timeout (could be caused by network delay), and by auto-retry on scheduled buys, they'd have a better chance of success.

Scheduled buys are different from manual buys, as they're usually executed unattended. So when scheduled buys failed, the users are usually not in front of the App to do the retry manually.